### PR TITLE
Changed the behaviour to slash command returning message attachments

### DIFF
--- a/hook.py
+++ b/hook.py
@@ -54,7 +54,7 @@ def send_message_back( payload ):
     headers = {'content-type': 'application/json', 'Accept-Charset': 'UTF-8'}
     r = requests.post(url, data=json.dumps(payload), headers=headers)
     if r.status_code != requests.codes.ok:
-        app.logger.error(r.status_code+' : '+r.text)
+        app.logger.error(str(r.status_code)+' : '+r.text)
 
     resp = Response(
         json.dumps({'text': '',

--- a/hook.py
+++ b/hook.py
@@ -5,6 +5,8 @@ import flask
 import jira
 import settings
 import re
+import requests
+import json
 
 # some aliasses
 request = flask.request
@@ -14,32 +16,42 @@ json = flask.json
 app = flask.Flask(__name__)
 
 
+
+
+
 @app.route('/', methods=['POST'])
 def receive_mattermost():
     """We only have 1 incoming hook"""
     form = request.form
     token = form.getlist('token')[0]
+    fromChannel = form.getlist('channel_name')[0]
+    userName = form.getlist('user_name')[0]
+    requestText = form.getlist('text')[0]
+    requestUserid = form.getlist('user_id')[0]
+    userIcon = settings.METTERMOST_URL+'/api/v3/users/'+requestUserid+'/image'
 
+    app.logger.error(form)
     if settings.MATTERMOST_TOKEN:
         if not token == settings.MATTERMOST_TOKEN:
             app.logger.error('Received wrong token, received [%s]', token)
-            return ''
+            return get_error_payload( fromChannel, requestText, userName, userIcon, "The integration is not correctly set up. Token not valid." )
 
-    ticket_id = search_token(form.getlist('text')[0])
+    ticket_id = search_token(requestText)
+#    app.logger.info('Search for ticket [%s]', ticked_id)
     if ticket_id is None:
-        return ''
+        return get_error_payload( fromChannel, requestText, userName, userIcon, "Could not identify jira issue ID." )
 
-    (icon, resp_str, project_name) = get_detail_from_jira(ticket_id)
+    payload = get_detail_from_jira(ticket_id, fromChannel, userName, requestText, requestUserid)
 
-    if resp_str is None:
-        return ''
+    if payload is None:
+        return get_error_payload( fromChannel, requestText, userName, userIcon, "There was an exception when searching for the issue in Jira." )
 
-    resp = Response(
-        json.dumps({'text': resp_str,
-                    'icon_url': icon,
-                    'username': project_name}),
-        status=200)
-    return resp
+    url = settings.METTERMOST_URL+'/hooks/'+settings.MATTERMOST_HOOK
+    headers = {'content-type': 'application/json', 'Accept-Charset': 'UTF-8'}
+    r = requests.post(url, data=json.dumps(payload), headers=headers)
+	return
+    #resp = Response( json.dumps(''), status=200 )
+    #return resp
 
 
 def search_token(text):
@@ -57,13 +69,28 @@ def parse_icon_name(field):
         '![](' + \
         field.iconUrl + ') ' +\
         field.name
+		
 
 
 def get_url(ticket_id):
     return '%s/browse/%s' % (settings.JIRA_URL, ticket_id)
 
+def get_color_for_issue(issue_status):
+    """Return the color matching the issue status in jira"""
+    return '%s/browse/%s' % (settings.JIRA_URL, ticket_id)
 
-def get_detail_from_jira(ticket_id):
+def get_error_payload( channel, text, user, icon, errorMessage ):
+    """Return the payload of the return message in case of an error"""
+    return {'channel': channel, 'text': text, 'username': user, 'icon_url': icon, 
+	          'attachments': [{
+                    'fallback': 'There was a problem with the Jira bot.',
+                    'color': settings.ERROR_COLOR,
+		            'text': errorMessage
+                  }]
+				}
+
+
+def get_detail_from_jira(ticket_id, fromChannel, userName, requestText, userIcon ):
     """Connect to JIRA and retrieve the details"""
 
     try:
@@ -72,35 +99,59 @@ def get_detail_from_jira(ticket_id):
     except jira.JIRAError:
         print('Connection error')
         app.logger.error('Could not connect to JIRA', exc_info=True)
-        return None
+        return get_error_payload( fromChannel, requestText, userName, userIcon, 'Could not connect to JIRA.')
 
     try:
         issues = jc.search_issues('key=%s' % ticket_id)
     except jira.JIRAError:
         app.logger.warning('Search on JIRA failed', exc_info=True)
-        return None
+        return get_error_payload( fromChannel, requestText, userName, userIcon, 'Search on JIRA failed')
 
     if not len(issues):
         # Could not find a matching ticket
-        return None
+        return get_error_payload( fromChannel, requestText, userName, userIcon, 'Could not find a matching ticket for %s' % (ticked_id))
+		
     issue = issues[0]
 
-    ret_str = \
-       '[%s - %s](%s "%s")' % (ticket_id, issue.fields.summary, get_url(ticket_id), ticket_id) \
-       + '\n\n' +\
-       'Reported by *%s*\n' % issue.fields.reporter.displayName + \
-       'Is being worked on by: *' + \
-       (issue.fields.assignee.displayName if issue.fields.assignee else 'Nobody') +\
-       '*\n' +\
-       'Type of the ticket: ' + parse_icon_name(issue.fields.issuetype) + '\n' +\
-       'Status of the ticket: ' + parse_icon_name(issue.fields.status) + '\n' +\
-       '- - -\n' +\
-       '%s' % issue.fields.description
+    issueTitle = '[%s - %s](%s "%s")' % (ticket_id, issue.fields.summary, get_url(ticket_id), ticket_id)
+    assignee = (issue.fields.assignee.displayName if issue.fields.assignee else 'Nobody')
+    issueType = parse_icon_name(issue.fields.issuetype)
+    issueStatus = parse_icon_name(issue.fields.status)
+    issueDescription = issue.fields.description
+    if issueDescription is None:
+	  issueDescription = '_~ No description for this issue ~_'
 
-    icon = issue.fields.project.raw['avatarUrls']['32x32']
-    project_name = issue.fields.project.name
+    formattedTitle = '#### ![](%s) [%s &nbsp;&nbsp;&nbsp; %s](%s "%s") ####' % (issue.fields.issuetype.iconUrl, ticket_id, issue.fields.summary, get_url(ticket_id), ticket_id)
+    colorForIssue = settings.COLORS_DICTONARY.get( issue.fields.status.name, '' )
+    formattedText = formattedTitle +'\n'+issueDescription
 
-    return (icon, ret_str, project_name)
+    payload = {'channel': fromChannel, 'text': requestText, 'username': userName,
+    'icon_url': userIcon,
+	'attachments': [{
+        'fallback': 'Jira issue posted.',
+        'color': colorForIssue,
+		'text': formattedText,
+		'fields': [
+        {
+          "short": True,
+          "title": "Type",
+          "value": issueType
+        },
+        {
+          "short": True,
+          "title": "Status",
+          "value": issueStatus
+        },
+        {
+        "short": False,
+        "title": "Assignee",
+        "value": assignee
+        }
+      ],
+    }]
+	}
+
+    return payload
 
 
 if __name__ == '__main__':

--- a/hook.py
+++ b/hook.py
@@ -42,7 +42,7 @@ def receive_mattermost():
         return send_message_back( get_error_payload( fromChannel, requestText, userName, userIcon, "Could not identify jira issue ID." ) )
 
 
-    payload = get_detail_from_jira(ticket_id, fromChannel, userName, requestText, requestUserid)
+    payload = get_detail_from_jira( ticket_id, fromChannel, userName, requestText, userIcon )
 
     if payload is None:
         return send_message_back( get_error_payload( fromChannel, requestText, userName, userIcon, "There was an exception when searching for the issue in Jira." ) )

--- a/runme.py
+++ b/runme.py
@@ -6,9 +6,10 @@ from tornado import httpserver
 from tornado import ioloop
 
 import hook
+import settings
 
 http_server = httpserver.HTTPServer(wsgi.WSGIContainer(hook.app))
-http_server.listen(5000)
+http_server.listen(settings.WEBSERVER_PORT)
 ioloop.IOLoop.instance().start()
 
 # vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4

--- a/settings.py.example
+++ b/settings.py.example
@@ -15,9 +15,6 @@ MATTERMOST_URL = 'https://mattermost.yourdomain.com'
 # http://docs.mattermost.com/developer/webhooks-outgoing.html
 MATTERMOST_TOKEN = None
 
-# Incomming Webhook UID:
-MATTERMOST_HOOK = 'kjhsd87jkhsdg54547sjhs'
-
 # You can define colors to use besides the message attachment to match Jira status codes:
 DEFAULT_COLOR = '#4A6785'; # fallback if no defined status code matches
 COLORS_DICTONARY = {

--- a/settings.py.example
+++ b/settings.py.example
@@ -29,6 +29,8 @@ COLORS_DICTONARY = {
     }
 ERROR_COLOR = '#FF141A' # in case there was an error we might send the message anyway but include some error message in the attachment.
 
+# Configure which port to use for teh webservice. Default: 5000
+WEBSERVER_PORT = 5000
 
 # vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4
 

--- a/settings.py.example
+++ b/settings.py.example
@@ -6,9 +6,36 @@ JIRA_USER = '<account with read privileges>'
 JIRA_PASS = '<password for the account>'
 
 # Match all possible tickets, change if subset is desired
-TICKET_REGEXP = r'[A-Z]{1,10}-[1-9][0-9]{0,3}'
-# Optionally, to secure the hook, see;
+TICKET_REGEXP = r'[A-Z]{1,10}-[1-9][0-9]{0,4}'
+
+# Mattermost base URL (no slash at the end):
+MATTERMOST_URL = 'https://mattermost.yourdomain.com'
+
+# Optionally, to secure the outgoing hook, see;
 # http://docs.mattermost.com/developer/webhooks-outgoing.html
 MATTERMOST_TOKEN = None
 
+# Incomming Webhook UID:
+MATTERMOST_HOOK = 'kjhsd87jkhsdg54547sjhs'
+
+# You can define colors to use besides the message attachment to match Jira status codes:
+DEFAULT_COLOR = '#4A6785'; # fallback if no defined status code matches
+COLORS_DICTONARY = {
+    'Fixed':'#FFD351',
+	'In Progress': '#FFD351',
+	'Done': '#14892C',
+	'Draft': '#4A6785',
+	'Closed': '#14892C',
+	'Ready': '#4A6785',
+    'Rejected': '#14892C',
+	'New': '#4A6785'
+    }
+ERROR_COLOR = '#FF141A' # in case there was an error we might send the message anyway but include some error message in the attachment.
+
+
 # vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4
+
+
+
+
+


### PR DESCRIPTION
In order to be able to get Jira issue information in every channel (also private messages) I changed the behaviour to use a slash command that returns the original message and an attachment showing the Jira info. The message is posted with the same username and icon as the sender of the slash command.